### PR TITLE
added gender identity under demographics activity

### DIFF
--- a/DemoProtocol/DemoProtocol_schema
+++ b/DemoProtocol/DemoProtocol_schema
@@ -22,6 +22,10 @@
 	],
 	"ui": {
         "addProperties": [
+            {"isAbout": "../activities/demographics/demographics_schema",
+            "variableName": "demographics_schema",
+            "prefLabel": {"en": "Demographics"}
+            },
             {"isAbout": "../activities/Activity1/activity1_schema",
             "variableName": "activity1_schema",
             "prefLabel": {"en": "Upload Documents"}
@@ -48,7 +52,8 @@
             }
         ],
     "order": [
-	    "../activities/Activity1/activity1_schema",
+            "../activities/demographics/demographics_schema",
+	        "../activities/Activity1/activity1_schema",
             "../activities/Activity2/Activity2_schema",
             "../activities/Activity3/Activity3_schema",
             "../activities/selectActivity/selectActivity_schema",

--- a/activities/demographics/demographics_schema
+++ b/activities/demographics/demographics_schema
@@ -1,0 +1,30 @@
+{
+    "@context": "https://raw.githubusercontent.com/ReproNim/reproschema/1.0.0-rc1/contexts/generic",
+    "@type": "reproschema:Activity",
+    "@id": "demographics_schema",
+    "prefLabel": "Demographics",
+    "description": "activity to collect demographics of the subject",
+    "preamble": "This activity will ask for your demographics.",
+    "schemaVersion": "1.0.0-rc1",
+    "version": "0.0.1",
+    "ui": {
+        "addProperties": [
+
+                {"isAbout": "items/gender_identity",
+                "variableName": "gender_identity",
+                "isVis": true,
+                  "allow": [
+                    "reproschema:Skipped"
+                ]
+                }
+        ],
+        "order": [
+            "items/gender_identity"
+        ],
+        "shuffle": false,
+        "allow": [
+			"reproschema:AutoAdvance",
+			"reproschema:AllowExport"
+		]
+    }
+}

--- a/activities/demographics/items/gender_identity
+++ b/activities/demographics/items/gender_identity
@@ -1,0 +1,72 @@
+{
+    "@context": "https://raw.githubusercontent.com/ReproNim/reproschema/1.0.0-rc2/contexts/generic",
+    "@type": "reproschema:Field",
+    "@id": "gender_identity",
+    "prefLabel": "Gender",
+    "description": "schema to identify gender of the subject",
+    "schemaVersion": "1.0.0-rc2",
+    "version": "0.0.1",
+    "question": {
+	    "en": "Gender identity (select all that apply):",
+	    "es": "Identidad de género (seleccione todas las que correspondan):"
+    },
+    "ui": {
+        "inputType": "radio"
+    },
+    "responseOptions": {
+        "valueType": "xsd:anyURI",
+	    "multipleChoice": true,
+        "choices": [
+            {
+                "name": {
+	                "en": "Cis woman",
+	                "es": "Mujer cis"
+                },
+                "value": 1
+            },
+            {
+                "name": {
+	                "en": "Cis man",
+	                "es": "Hombre cis"
+                },
+                "value": 2
+            },
+	        {
+                "name": {
+	                "en": "Trans woman",
+	                "es": "Mujer trans"
+                },
+                "value": 3
+            },
+	        {
+                "name": {
+	                "en": "Trans man",
+	                "es": "Hombre trans"
+                },
+                "value": 4
+            },
+	        {
+                "name": {
+	                "en": "Non-binary",
+	                "es": "No binario(e)"
+                },
+                "value": 5
+            },
+	        {
+                "name": {
+	                "en": "Prefer not to disclose",
+	                "es": "Prefiero no responder"
+                },
+                "value": 0
+            },
+	        {
+                "name": {
+	                "en": "Other",
+	                "es": "Otro"
+                },
+                "value": -1
+            }
+
+        ]
+    }
+}

--- a/ui-changes/src/config.js
+++ b/ui-changes/src/config.js
@@ -1,6 +1,6 @@
 module.exports = {
   /* eslint-disable */
-  githubSrc: 'https://raw.githubusercontent.com/ReproNim/demo-protocol/master/DemoProtocol/DemoProtocol_schema',
+  githubSrc: 'https://raw.githubusercontent.com/sooyounga/demo-protocol/master/DemoProtocol/DemoProtocol_schema',
   banner: 'This is a demonstration protocol for ReproSchema.',
   startButton: 'Join',
   assetsPublicPath: '/demo-protocol/',


### PR DESCRIPTION
- used gender identity item file under demographics activity folder in reproschema-library (https://github.com/ReproNim/reproschema-library/blob/master/activities/demographics_and_background_information_v1/items/gender_identity)
- edited the above file to include cisgender 
- added the new schema 
- added the new property 
- changed config to my github page 